### PR TITLE
provide enum for ufos.size

### DIFF
--- a/schemas/oxc/RuleUfo.json
+++ b/schemas/oxc/RuleUfo.json
@@ -11,7 +11,14 @@
       "type": "string"
     },
     "size": {
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "STR_VERY_SMALL",
+        "STR_SMALL",
+        "STR_MEDIUM_UC",
+        "STR_LARGE",
+        "STR_VERY_LARGE"
+      ]
     },
     "sprite": {
       "type": "integer"


### PR DESCRIPTION
As per the discussion here: https://discord.com/channels/292085473890009088/330653502693179394/943865248077709312

It seems that any other value than these could cause unexpected behaviour, so they should be validated.